### PR TITLE
Update deployment step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Telegram-driven to-do and calendar assistant powered by Gemini 1.5 Pro. Chat wit
 1. Install dependencies: Python 3.11, Node.js, Expo, Supabase CLI.
 2. Copy `infra/.env.example` to `.env` and fill in values. `SUPABASE_FUNCTION_JWT_SECRET` is used to sign requests to the edge function.
 3. `supabase db push` – apply database schema.
-4. `fly deploy` – deploy FastAPI worker.
+4. `railway up` – deploy FastAPI worker.
 5. `expo start` – run the mobile app.
 
 See the [docs](docs/) directory for architecture, roadmap and more.


### PR DESCRIPTION
## Summary
- update README deployment step to use Railway instead of Fly.io

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859d7901b5483299000d174ed51ff03