### PR TITLE
Update README with edge function note

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Telegram-driven to-do and calendar assistant powered by Gemini 1.5 Pro. Chat wit
 2. Copy `infra/.env.example` to `.env` and fill in values. `SUPABASE_FUNCTION_JWT_SECRET` is used to sign requests to the edge function.
 3. `supabase db push` – apply database schema.
 4. `supabase functions deploy telegram_webhook`
+   This edge function handles incoming Telegram updates and must be deployed before running the mobile app.
 5. `curl "https://api.telegram.org/bot$TOKEN/setWebhook?url=$(supabase functions deploy telegram_webhook --project-ref <ref> --no-verify-jwt --no-verbose)/"`
 6. `expo start` – run the mobile app.
 


### PR DESCRIPTION
## Summary
- document why the `telegram_webhook` edge function must be deployed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a7fc0809083299da760575593467d