### PR TITLE
Update hosting choice in implementation docs

### DIFF
--- a/docs/implementation_choices.md
+++ b/docs/implementation_choices.md
@@ -6,4 +6,4 @@
 | **Storage** | Supabase Postgres | 0 $ / <500 MB DB, instant REST & RLS. |
 | **Mobile** | React Native + Expo | One codebase, OTA updates, push notifications. |
 | **Notifications** | Expo Push + Telegram fallback | Native alerts + chat replies. |
-| **Hosting** | Railway free | Runs FastAPI worker + cron; custom domain for webhook. |
+| **Hosting** | Supabase Edge Functions (free) | Runs the Telegram webhook and cron on Supabase. |


### PR DESCRIPTION
## Summary
- switch hosting from Railway to Supabase Edge Functions
- note that the Telegram webhook and cron now run on Supabase

## Testing
- `ruff check backend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a9400c49c832987e691257666af78