### PR TITLE
Update roadmap to reference Supabase edge function

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 Phase | Scope | Est. time
 --- | --- | ---
-0 – Bootstrap | Repo scaffolding, Supabase tables, Railway app, Telegram webhook. | 3–4 h
+0 – Bootstrap | Repo scaffolding, Supabase tables, Supabase edge function, Telegram webhook. | 3–4 h
 1 – MVP | Free-form parsing → Gemini → tasks; Expo list views; push reminders. | Weekend
 2 – QoL | Recurring rules, snooze, offline cache, swipe to complete. | +1 week
 3 – Calendar sync | Google Calendar OAuth + AI slot suggestion. | +2 weeks


### PR DESCRIPTION
## Summary
- edit roadmap to use a Supabase edge function rather than a Railway app

## Testing
- `cat docs/roadmap.md`

------
https://chatgpt.com/codex/tasks/task_e_685a94cb19c4832987ef97baf606c3fa