### PR TITLE
Fix Telegram webhook task

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,5 +1,5 @@
 - [ ] Bootstrap repository and configure Supabase tables
-- [ ] Deploy FastAPI bot worker on Railway and set Telegram webhook
+- [ ] Deploy Supabase edge function for Telegram webhook
 - [ ] Connect Expo app to Supabase and display tasks
 - [ ] Parse free-form text via Gemini to structured tasks
 - [ ] Send push notifications for due tasks


### PR DESCRIPTION
## Summary
- update checklist reference to use Supabase edge function

## Testing
- `ruff check backend`
- `pytest -q`
- `npx expo lint` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685aa0543c6c832988669b4c3eb328ee