### PR TITLE
Fix docs and webhook variable clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,8 @@ See [mobile/README.md](mobile/README.md) for details.
 
 ## ⚙️ Configuration & Deploy
 
-* **Import Maps**: Controlled by `import_map.json` for Deno dep pinning.
 * **Edge Function**: Lives under `supabase/functions/telegram_webhook/`.
-* **Database Schema**: Defined in `infra/schema.sql`.
+* **Database Schema**: Defined in `schema/schema.sql`.
 
 ---
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,19 @@
+# Mobile App
+
+This folder contains the React Native app built with **Expo**. It connects to Supabase and receives realtime updates for tasks.
+
+## Development
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Start the Expo dev server:
+
+```bash
+expo start
+```
+
+The app expects the Supabase URL and anon key to be provided via the Expo config in `app.json` or `app.config.js`.

--- a/supabase/functions/telegram_webhook/index.ts
+++ b/supabase/functions/telegram_webhook/index.ts
@@ -15,7 +15,6 @@ serve(async (req) => {
   const {
     SPBASE_URL,
     SPBASE_SERVICE_ROLE_KEY,
-    TELEGRAM_TOKEN
   } = Deno.env.toObject();
 
   if (!SPBASE_URL || !SPBASE_SERVICE_ROLE_KEY || !TELEGRAM_TOKEN) {


### PR DESCRIPTION
## Summary
- remove outdated import_map reference
- fix schema path in docs
- avoid TELEGRAM_TOKEN redeclaration in webhook
- add README for mobile app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2c51b9bc8329bf46bf22e38967f4