### PR TITLE
Update Expo CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ For a full walkthrough of running the bot and app locally see [docs/development.
    ```bash
    python -m venv venv && source venv/bin/activate
    npm install
-   npm install -g expo-cli
    ```
 
 3. **Configure environment**
@@ -118,7 +117,7 @@ For a full walkthrough of running the bot and app locally see [docs/development.
    ```bash
    cd mobile
    cp .env.example .env  # add SPBASE_URL and SPBASE_ANON_KEY
-   expo start
+   npx expo start
    ```
 
 ---

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ This guide explains how to run the Telegram bot, Supabase functions and mobile a
 - [Python](https://www.python.org/) 3.11
 - [Node.js](https://nodejs.org/) >= 18
 - [Supabase CLI](https://supabase.com/docs/guides/cli) (`npm install -g supabase`)
-- [Expo CLI](https://docs.expo.dev/workflow/expo-cli/) (`npm install -g expo-cli`)
+- [Expo CLI](https://docs.expo.dev/workflow/expo-cli/) (via `npx expo`)
 
 Docker is required if you want to start a local Postgres instance with `supabase start`.
 
@@ -28,11 +28,10 @@ source venv/bin/activate
 pip install -r backend/requirements.txt
 ```
 
-Install Node dependencies and the Expo tooling:
+Install Node dependencies:
 
 ```bash
 npm install
-npm install -g expo-cli
 ```
 
 
@@ -102,7 +101,7 @@ Inside the `mobile` folder install dependencies and start the Expo dev server:
 ```bash
 cd mobile
 npm install
-expo start
+npx expo start
 ```
 
 The app will read the Supabase URL and anon key from `mobile/.env`.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -20,7 +20,7 @@ cp .env.example .env
 3. Start the Expo dev server:
 
 ```bash
-expo start
+npx expo start
 ```
 
 The app reads the Supabase URL and anon key from `app.config.js`, which loads them from `.env`.


### PR DESCRIPTION
## Summary
- update local dev instructions for `npx expo start`
- drop global expo-cli install steps

## Testing
- `ruff check backend`
- `pytest`
- `npx expo lint` *(fails: 403 Forbidden due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_68643b1981308329b0ce35e2a8d2763e