### PR TITLE
Implement realtime updates and new mobile UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Secure and validate incoming updates from Telegram by using a dedicated secret t
 - Built with **React Native** and **Expo**.
 - Connects to Supabase for real-time data.
 - Supports adding, editing, and completing tasks.
+- Modern card-based UI updates instantly when new tasks arrive.
 - Calendar view for reminders.
 
 See [mobile/README.md](mobile/README.md) for details.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,7 +21,7 @@ The project evolves in several phases. Each phase groups related tasks from `tas
 
 ### Phase 1 – MVP
 1. Parse messages with Gemini and store structured tasks.
-2. Display tasks in the Expo app with realtime updates.
+2. Display tasks in the Expo app with realtime updates and a modern UI. ✅
 3. Send push notifications when tasks are due.
 
 ### Phase 2 – Quality of Life

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -11,6 +11,8 @@
   `mobile/App.tsx` subscribes to the `tasks` table and renders a list of items.
 - [x] **Parse free-form text via Gemini to structured tasks**
   `telegram_webhook` now calls Gemini's API with function calling and stores structured tasks.
+- [x] **Realtime updates & modern UI for tasks**
+  The Expo app listens for `postgres_changes` and displays tasks in a card-based layout.
 - [ ] **Send push notifications for due tasks**
   Schedule a cron job to trigger Expo push notifications when tasks are due.
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { FlatList, Text, View, Platform } from "react-native";
+import {
+  FlatList,
+  Text,
+  View,
+  Platform,
+  SafeAreaView,
+  StyleSheet,
+} from "react-native";
 import Constants from "expo-constants";
 import * as Notifications from "expo-notifications";
 import { createClient } from "@supabase/supabase-js";
@@ -10,24 +17,55 @@ const supabase = createClient(supabaseUrl!, supabaseKey!);
 
 export default function App() {
   const [tasks, setTasks] = useState<any[]>([]);
+  const [lists, setLists] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    const subscription = supabase
-      .channel("public:tasks")
+    const channel = supabase.channel("public:tasks");
+    channel
       .on(
         "postgres_changes",
-        { event: "*", schema: "public", table: "tasks" },
+        { event: "INSERT", schema: "public", table: "tasks" },
         (payload) => {
-          fetchTasks();
+          const record: any = payload.new;
+          setTasks((prev) => [
+            {
+              ...record,
+              listName: lists[record.list_id] || "Inbox",
+            },
+            ...prev,
+          ]);
+        },
+      )
+      .on(
+        "postgres_changes",
+        { event: "UPDATE", schema: "public", table: "tasks" },
+        (payload) => {
+          const record: any = payload.new;
+          setTasks((prev) =>
+            prev.map((t) =>
+              t.id === record.id
+                ? { ...t, ...record, listName: lists[record.list_id] || "Inbox" }
+                : t,
+            ),
+          );
+        },
+      )
+      .on(
+        "postgres_changes",
+        { event: "DELETE", schema: "public", table: "tasks" },
+        (payload) => {
+          const record: any = payload.old;
+          setTasks((prev) => prev.filter((t) => t.id !== record.id));
         },
       )
       .subscribe();
 
+    fetchTaskLists();
     fetchTasks();
     registerDeviceToken();
 
     return () => {
-      subscription.unsubscribe();
+      channel.unsubscribe();
     };
   }, []);
 
@@ -46,18 +84,69 @@ export default function App() {
     }
   }
 
+  async function fetchTaskLists() {
+    const { data } = await supabase.from("task_lists").select("id, name");
+    if (data) {
+      const map: Record<string, string> = {};
+      data.forEach((l) => {
+        map[l.id] = l.name;
+      });
+      setLists(map);
+    }
+  }
+
   async function fetchTasks() {
-    const { data } = await supabase.from("tasks").select("*");
-    setTasks(data || []);
+    const { data } = await supabase
+      .from("tasks")
+      .select("id, title, due_at, important, list_id")
+      .order("created_at", { ascending: false });
+    if (data) {
+      setTasks(
+        data.map((t) => ({
+          ...t,
+          listName: lists[t.list_id] || "Inbox",
+        })),
+      );
+    }
   }
 
   return (
-    <View style={{ marginTop: 50 }}>
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.header}>My Tasks</Text>
       <FlatList
         data={tasks}
         keyExtractor={(item) => item.id}
-        renderItem={({ item }) => <Text>{item.title}</Text>}
+        contentContainerStyle={{ paddingBottom: 40 }}
+        renderItem={({ item }) => (
+          <View style={styles.card}>
+            <Text style={styles.title}>{item.title}</Text>
+            <Text style={styles.meta}>
+              {item.listName}
+              {item.due_at
+                ? ` • Due ${new Date(item.due_at).toLocaleDateString()}`
+                : ""}
+            </Text>
+          </View>
+        )}
       />
-    </View>
+    </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#f8f8f8" },
+  header: { fontSize: 24, fontWeight: "bold", padding: 20 },
+  card: {
+    backgroundColor: "#fff",
+    marginHorizontal: 16,
+    marginVertical: 8,
+    borderRadius: 8,
+    padding: 16,
+    shadowColor: "#000",
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  title: { fontSize: 16, fontWeight: "500" },
+  meta: { fontSize: 12, color: "#666", marginTop: 4 },
+});


### PR DESCRIPTION
## Summary
- mobile app now uses Supabase realtime listeners to update when tasks change
- modern card-based UI for tasks and their lists
- document new feature in roadmap and tasks docs
- README mobile section mentions the improved UI

## Testing
- `ruff check backend`
- `pytest`
- `npx expo lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo)*

------
https://chatgpt.com/codex/tasks/task_e_686469f8d55c8329b3ff7838fbcfe8cb