### PR TITLE
Add pull-to-refresh to mobile app

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -6,6 +6,7 @@ import {
   Platform,
   SafeAreaView,
   StyleSheet,
+  RefreshControl,
 } from "react-native";
 import Constants from "expo-constants";
 import * as Notifications from "expo-notifications";
@@ -19,6 +20,7 @@ export default function App() {
   const [tasks, setTasks] = useState<any[]>([]);
   const [lists, setLists] = useState<Record<string, string>>({});
   const listsRef = useRef<Record<string, string>>({});
+  const [refreshing, setRefreshing] = useState(false);
 
   // keep ref updated with the latest lists mapping
   useEffect(() => {
@@ -116,6 +118,13 @@ export default function App() {
     }
   }
 
+  async function onRefresh() {
+    setRefreshing(true);
+    await fetchTaskLists();
+    await fetchTasks();
+    setRefreshing(false);
+  }
+
   return (
     <SafeAreaView style={styles.container}>
       <Text style={styles.header}>My Tasks</Text>
@@ -123,6 +132,9 @@ export default function App() {
         data={tasks}
         keyExtractor={(item) => item.id}
         contentContainerStyle={{ paddingBottom: 40 }}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
         renderItem={({ item }) => (
           <View style={styles.card}>
             <Text style={styles.title}>{item.title}</Text>


### PR DESCRIPTION
## Summary
- allow manual refreshing by pulling down on the task list

## Testing
- `ruff check backend`
- `pytest`
- `cd mobile && npx expo lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686518ae3608832986165c55460aafd0